### PR TITLE
Changes to support  multiple modalBox instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Check [index.js](https://github.com/maxs15/react-native-modalbox/blob/master/Exa
 | startOpen | false | `bool` | Allow modal to appear open without animation upon first mount
 | coverScreen | false | `bool` | Will use RN `Modal` component to cover the entire screen wherever the modal is mounted in the component hierarchy
 | keyboardTopOffset | ios:22, android:0 | `number` | This property prevent the modal to cover the ios status bar when the modal is scrolling up because the keyboard is opening
+| shouldAddToHistory | true | `bool` | Will add modal to browser history
 
 ## Events
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,10 @@ export default class ModalBox extends React.Component{
     }
 
     componentWillReceiveProps(nextProps) {
-        this.handleOpenning(nextProps);
+        // Since handleOpenning only checks for isOpen, so we should have a check here for the prop change.
+        if(nextProps.isOpen !== this.props.isOpen) {
+            this.handleOpenning(nextProps);
+        }
     }
 
     handleOpenning = (props) => {

--- a/index.js
+++ b/index.js
@@ -11,8 +11,6 @@ import {
     Platform
 } from 'react-native';
 
-const screen = Dimensions.get('window');
-
 const styles = StyleSheet.create({
 
     wrapper: {
@@ -36,7 +34,8 @@ const styles = StyleSheet.create({
 export default class ModalBox extends React.Component{
     constructor(props) {
         super(props);
-        const position = this.props.inplace ? 0 : this.props.entry === 'top' ? -screen.height : screen.height;
+        this.contentScreen = Dimensions.get('window');
+        const position = this.props.inplace ? 0 : this.props.entry === 'top' ? -this.contentScreen.height : this.contentScreen.height;
         this.state = {
             position: new Animated.Value(position),
             backdropOpacity: new Animated.Value(0),
@@ -44,10 +43,10 @@ export default class ModalBox extends React.Component{
             isAnimateClose: false,
             isAnimateOpen: false,
             swipeToClose: false,
-            height: screen.height,
-            width: screen.width,
-            containerHeight: screen.height,
-            containerWidth: screen.width,
+            height: this.contentScreen.height,
+            width: this.contentScreen.width,
+            containerHeight: this.contentScreen.height,
+            containerWidth: this.contentScreen.width,
             isInitialized: false
         };
     }
@@ -181,7 +180,7 @@ export default class ModalBox extends React.Component{
         this.state.animClose = Animated.timing(
             this.state.position,
             {
-                toValue: this.props.inplace ? 0 : this.props.entry === 'top' ? -(this.state.containerHeight + screen.height) : (this.state.containerHeight + screen.height),
+                toValue: this.props.inplace ? 0 : this.props.entry === 'top' ? -(this.state.containerHeight + this.contentScreen.height) : (this.state.containerHeight + this.contentScreen.height),
                 duration: this.props.animationDuration,
                 easing: Easing.bezier(0.4, 0, 0.2, 1)
             }
@@ -334,7 +333,7 @@ export default class ModalBox extends React.Component{
     render() {
         var visible = this.state.isOpen || this.state.isAnimateOpen || this.state.isAnimateClose;
         var size = { height: this.state.containerHeight, width: this.state.containerWidth };
-        var offsetX = (this.state.containerWidth - this.state.width) / 2;
+        var offsetX = this.props.inplace ? 0 : (this.state.containerWidth - this.state.width) / 2;
         var backdrop = this.renderBackdrop(size);
 
         if (!visible) {

--- a/index.js
+++ b/index.js
@@ -362,7 +362,7 @@ export default class ModalBox extends React.Component{
                 this.animateOpen();
             };
             this.setState({ isAnimateOpen: true });
-            if (window && window.history && window.history.pushState) {
+            if (window && window.history && window.history.pushState && this.props.shouldAddToHistory) {
                 // Since we can have multiple instances of modalBox then all instances will listen to popstate.
                 // So all the instance will close with a single back.
                 // To make it work we will pass the id (default id is 'MODAL_BOX') to each instance and we will use that id to decide which instance to close.
@@ -400,7 +400,7 @@ export default class ModalBox extends React.Component{
 
     close = () => {
         if (this.props.isDisabled) return;
-        if (!this.state.isAnimateClose && (this.state.isOpen || this.state.isAnimateOpen) && window && window.history) {
+        if (!this.state.isAnimateClose && (this.state.isOpen || this.state.isAnimateOpen) && window && window.history && this.props.shouldAddToHistory) {
             window.history.back();
         }
     }
@@ -420,5 +420,6 @@ ModalBox.defaultProps = {
     showFullscreen: false,
     resizeToFullscreen: false,
     id: 'MODAL_BOX',
-    stopImmediatePropagation: false
+    stopImmediatePropagation: false,
+    shouldAddToHistory: true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-web-modalbox",
-  "version": "0.0.17",
+  "version": "0.0.19",
   "description": "A <Modal/> component for react-native and react-native-web",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-web-modalbox",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "A <Modal/> component for react-native and react-native-web",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-web-modalbox",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "A <Modal/> component for react-native and react-native-web",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-web-modalbox",
-  "version": "0.0.12-beta.1",
+  "version": "0.0.16",
   "description": "A <Modal/> component for react-native and react-native-web",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-web-modalbox",
-  "version": "0.0.22",
+  "version": "0.0.25",
   "description": "A <Modal/> component for react-native and react-native-web",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-web-modalbox",
-  "version": "0.0.19",
+  "version": "0.0.22",
   "description": "A <Modal/> component for react-native and react-native-web",
   "main": "index.js",
   "scripts": {

--- a/portal.js
+++ b/portal.js
@@ -21,10 +21,12 @@ export default class Portal extends Component {
         this.state.target.appendChild(this.state.el);
       }
     );
+    document.body.style.overflow = 'hidden';
   }
 
   componentWillUnmount() {
     this.state.target.removeChild(this.state.el);
+    document.body.style.overflow = 'visible';
   }
 
   render() {

--- a/portal.js
+++ b/portal.js
@@ -14,7 +14,7 @@ export default class Portal extends Component {
 
   componentDidMount() {
     const el = document.createElement('div');
-    el.setAttribute("style", "position: fixed;top: 0;left: 0;bottom: 0;right: 0;");
+    el.setAttribute("style", "position: fixed;top: 0;left: 0;bottom: 0;right: 0;z-index: 100;");
     this.setState(
       { el, target: document.body },
       () => {


### PR DESCRIPTION
1). Since we can have multiple instances of modalBox then all instances will listen to popstate.
So all the instance will close with a single back. To make it work we will pass the id (default id is 'MODAL_BOX') to each instance and we will use that id to decide which instance to close.
Also I have made the flow unidirectional, so that each time closing the modal should go through popstate inspite of how the user has done back operation.

2). Also added a registry in batman that will subscribe to popstate once and we will subscribe to registry to avoid multiple onpopstate subscriptions.