### PR TITLE
Added floating modal fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,6 @@ import {
     Platform
 } from 'react-native';
 
-const screen = Dimensions.get('window');
-
 const styles = StyleSheet.create({
 
     wrapper: {
@@ -36,7 +34,8 @@ const styles = StyleSheet.create({
 export default class ModalBox extends React.Component{
     constructor(props) {
         super(props);
-        const position = this.props.inplace ? 0 : this.props.entry === 'top' ? -screen.height : screen.height;
+        this.contentScreen = Dimensions.get('window');
+        const position = this.props.inplace ? 0 : this.props.entry === 'top' ? -this.contentScreen.height : this.contentScreen.height;
         this.state = {
             position: new Animated.Value(position),
             backdropOpacity: new Animated.Value(0),
@@ -44,10 +43,10 @@ export default class ModalBox extends React.Component{
             isAnimateClose: false,
             isAnimateOpen: false,
             swipeToClose: false,
-            height: screen.height,
-            width: screen.width,
-            containerHeight: screen.height,
-            containerWidth: screen.width,
+            height: this.contentScreen.height,
+            width: this.contentScreen.width,
+            containerHeight: this.contentScreen.height,
+            containerWidth: this.contentScreen.width,
             isInitialized: false
         };
     }
@@ -181,7 +180,7 @@ export default class ModalBox extends React.Component{
         this.state.animClose = Animated.timing(
             this.state.position,
             {
-                toValue: this.props.inplace ? 0 : this.props.entry === 'top' ? -(this.state.containerHeight + screen.height) : (this.state.containerHeight + screen.height),
+                toValue: this.props.inplace ? 0 : this.props.entry === 'top' ? -(this.state.containerHeight + this.contentScreen.height) : (this.state.containerHeight + this.contentScreen.height),
                 duration: this.props.animationDuration,
                 easing: Easing.bezier(0.4, 0, 0.2, 1)
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-web-modalbox",
-  "version": "0.0.19",
+  "version": "0.0.21",
   "description": "A <Modal/> component for react-native and react-native-web",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Since, the screen was initialised before component is called, the value of screen is the initial size of screen. 
SO, if size of screen is changed for example if the address bars hides, the modal animating calculation is done based on initial screen.height which gave wrong result and the modal box seems floating. 
So, to resolve it we need to find height in constructor. 